### PR TITLE
Update setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,5 +16,5 @@ setup(
         'Programming Language :: Python :: 3.7',
     ],
     packages=['pushy', 'pushy.lib', 'pushy.util'],
-    install_requires=['paho-mqtt']
+    install_requires=['paho-mqtt==1.6.1']
 )


### PR DESCRIPTION
Lock paho-mqtt to version 1.6.1 until an update can be made for paho-mqtt 2.0 which breaks pushy-python.